### PR TITLE
CQW-178 Fix nav links in footer

### DIFF
--- a/source/stylesheets/modules/_m-job-offer-element.scss
+++ b/source/stylesheets/modules/_m-job-offer-element.scss
@@ -14,6 +14,10 @@
     }
   }
 
+  &.m-grid-element::before {
+    display: none;
+  }
+
   .send-mail-link {
     color: $light-gray;
     font-family: $alega;


### PR DESCRIPTION
## TO DO:
* [X] Hide `:before` pseudo class for grid element on job offer page because it covered nav links in footer. Anyway this pseudo class is not needed here.

---

https://codequest.atlassian.net/browse/CQW-178

---

Review:
* [ ] @kruszczynski 
* [x] @pjar 
* [ ] @rpietraszko 
* [x] @MagdaMalinowska 