### PR TITLE
Fix Typo on start your project

### DIFF
--- a/source/partials/_start-your-project.html.slim
+++ b/source/partials/_start-your-project.html.slim
@@ -23,7 +23,7 @@
         .relative
           label.form-label Email address:
           input.form-input(data-js='email' type='text' name='_reply_to'
-            placeholder='We will keep it safe.We promise!')
+            placeholder='We will keep it safe. We promise!')
           .error-msg.hidden Email is invalid.
 
       fieldset.form-fieldset


### PR DESCRIPTION
Fix: "przed "we" spacji brakuje - podstrona start your project" -bug